### PR TITLE
Fix leaked_handle error reported by coverity

### DIFF
--- a/audio_hw.c
+++ b/audio_hw.c
@@ -1275,6 +1275,7 @@ static void *in_socket_server_thread(void *args)
                 {
                     ALOGE("%s: client_id %d exceeds the maximum concurrent user supported",
                           __FUNCTION__, user_id);
+                    close(new_client_fd);
                     return NULL;
                 }
             }


### PR DESCRIPTION
The handle new_client_fd was getting leaked when returning from an error scenario inside in_socket_server_thread.
Closed the new_client_fd handle before returning.

Tracked-On: OAM-111186